### PR TITLE
Fix root layout centering

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -29,9 +29,11 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
+  min-height: 100vh;
+}
+
+#root {
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## Summary
- remove flex centering styles from the body to allow the root element to span the viewport
- ensure the root element keeps the viewport height so auth layout wrappers can center their content

## Testing
- npm run dev
- Manually verified `/auth` and `/profile` center their content horizontally on wide screens


------
https://chatgpt.com/codex/tasks/task_e_68ce3a2c3c78832989b256115f6cb39e