### PR TITLE
Add Toss autopay enrollment button on profile

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -20,3 +20,7 @@ export const AuthAPI = {
   refresh: (refreshToken)  => api("/api/auth/refresh", { method: "POST", body: { refreshToken } }),
   me:      (access)        => api("/api/identity/me",  { access }),
 };
+
+export const PaymentsAPI = {
+  getTossAutopayUrl: (access) => api("/api/payments/toss/autopay", { access }),
+};


### PR DESCRIPTION
## Summary
- add a PaymentsAPI helper that requests the Toss autopay URL with the caller's access token
- surface a Toss-branded autopay button on the profile page with loading and error handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce3e5a34bc8329a980ab0090c9fea1