### PR TITLE
Add profile tabs and device management

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -24,3 +24,10 @@ export const AuthAPI = {
 export const PaymentsAPI = {
   getTossAutopayUrl: (access) => api("/api/payments/toss/autopay", { access }),
 };
+
+export const DevicesAPI = {
+  list:    (access)         => api("/api/devices",            { access }),
+  detail:  (deviceId, access) => api(`/api/devices/${deviceId}`, { access }),
+  register: (payload, access) => api("/api/devices",          { method: "POST", body: payload, access }),
+  remove:  (deviceId, access) => api(`/api/devices/${deviceId}`, { method: "DELETE", access }),
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { fileURLToPath, URL } from 'node:url'
+import process from 'node:process'
 
 export default defineConfig(({ mode }) => {
   // 현재 mode(dev/prod 등)에 맞는 .env 파일 로드


### PR DESCRIPTION
## Summary
- add a DevicesAPI helper that forwards the bearer token for smartcane device routes
- refactor the profile page to use tabs for profile, payment, and device management, mirroring existing tab styling
- lazily load the authenticated user’s devices with loading, empty, and error states and ensure lint compatibility in Vite config

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7381c787083299658ddd23f92d410