### PR TITLE
feat: enhance profile page device management

### DIFF
--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -1,52 +1,27 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useAuth } from "@/contexts/AuthContext";
-import { DevicesAPI, PaymentsAPI } from "@/lib/api";
-import { Loader2, LogOut } from "lucide-react";
-
-const PROFILE_SECTIONS = [
-  {
-    title: "기본 정보",
-    fields: [
-      { key: "nickname", label: "닉네임" },
-      { key: "email", label: "이메일" },
-      { key: "birthDate", label: "생년월일" },
-      { key: "phoneNumber", label: "전화번호" },
-    ],
-  },
-  {
-    title: "시스템 정보",
-    fields: [
-      { key: "id", label: "회원 ID" },
-      { key: "createdAt", label: "가입일" },
-      { key: "updatedAt", label: "정보 수정일" },
-      { key: "roles", label: "권한" },
-    ],
-  },
-];
-
-const KNOWN_PROFILE_KEYS = new Set(
-  PROFILE_SECTIONS.flatMap((section) => section.fields.map((field) => field.key))
-);
+import { PaymentsAPI } from "@/lib/api";
+import { LogOut } from "lucide-react";
+import ProfileOverview from "./components/ProfileOverview";
+import PaymentsTab from "./components/PaymentsTab";
+import DevicesTab from "./components/DevicesTab";
 
 export default function ProfilePage() {
   const auth = useAuth();
   const profile = auth?.me;
+
   const [tossLoading, setTossLoading] = useState(false);
   const [tossError, setTossError] = useState("");
   const [tabValue, setTabValue] = useState("profile");
-  const [devices, setDevices] = useState([]);
-  const [devicesLoading, setDevicesLoading] = useState(false);
-  const [devicesError, setDevicesError] = useState("");
-  const [devicesFetched, setDevicesFetched] = useState(false);
 
   const primaryName = profile?.nickname || profile?.name || profile?.email || "사용자";
-
   const hasAccessToken = Boolean(auth?.accessToken);
 
   const handleTossAutopay = async () => {
+    // 토스 자동이체 연동 시도 전 간단한 권한 체크를 수행합니다.
     if (!hasAccessToken) {
       setTossError("자동이체 등록은 로그인 후 이용 가능합니다.");
       return;
@@ -82,12 +57,8 @@ export default function ProfilePage() {
     return `${words[0][0] || ""}${words[1][0] || ""}`.toUpperCase();
   }, [primaryName]);
 
-  const extraEntries = useMemo(() => {
-    if (!profile || typeof profile !== "object") return [];
-    return Object.entries(profile).filter(([key]) => !KNOWN_PROFILE_KEYS.has(key));
-  }, [profile]);
-
-  const renderValue = (value) => {
+  const renderValue = useCallback((value) => {
+    // 화면 전체에서 동일한 렌더링 규칙을 쓰기 위해 함수로 분리했습니다.
     if (value === null || value === undefined || value === "") return "미입력";
     if (Array.isArray(value)) return value.length ? value.join(", ") : "미입력";
     if (value instanceof Date) return value.toLocaleDateString();
@@ -96,73 +67,13 @@ export default function ProfilePage() {
       return keys.length ? JSON.stringify(value) : "미입력";
     }
     return String(value);
-  };
-
-  useEffect(() => {
-    setDevicesFetched(false);
-    setDevices([]);
-    setDevicesError("");
-  }, [auth?.accessToken]);
-
-  useEffect(() => {
-    if (tabValue !== "devices") return;
-    if (!hasAccessToken) return;
-    if (devicesFetched) return;
-
-    let cancelled = false;
-
-    const normaliseDeviceList = (payload) => {
-      if (!payload) return [];
-      if (Array.isArray(payload)) return payload;
-      if (Array.isArray(payload?.devices)) return payload.devices;
-      if (Array.isArray(payload?.items)) return payload.items;
-      if (Array.isArray(payload?.data)) return payload.data;
-      if (Array.isArray(payload?.content)) return payload.content;
-      if (payload?.device && typeof payload.device === "object") return [payload.device];
-      if (typeof payload === "object") {
-        if ("id" in payload || "deviceId" in payload || "serialNumber" in payload) {
-          return [payload];
-        }
-      }
-      return [];
-    };
-
-    const fetchDevices = async () => {
-      setDevicesLoading(true);
-      setDevicesError("");
-      try {
-        const response = await DevicesAPI.list(auth.accessToken);
-        if (cancelled) return;
-        const list = normaliseDeviceList(response);
-        setDevices(Array.isArray(list) ? list : []);
-      } catch (error) {
-        if (cancelled) return;
-        setDevicesError(error?.message || "디바이스 정보를 불러오지 못했습니다.");
-        setDevices([]);
-      } finally {
-        if (!cancelled) {
-          setDevicesLoading(false);
-          setDevicesFetched(true);
-        }
-      }
-    };
-
-    fetchDevices();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [auth?.accessToken, devicesFetched, hasAccessToken, tabValue]);
-
-  const handleReloadDevices = () => {
-    setDevicesFetched(false);
-  };
+  }, []);
 
   if (!profile) return <p className="text-gray-500 text-center">로딩 중...</p>;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50 p-6">
-      <Card className="w-full max-w-md shadow-xl">
+      <Card className="w-full max-w-2xl shadow-xl">
         <CardHeader className="flex justify-between items-center">
           <CardTitle>프로필</CardTitle>
           <Button variant="ghost" size="icon" onClick={auth.logout} title="로그아웃">
@@ -178,133 +89,31 @@ export default function ProfilePage() {
             </TabsList>
 
             <TabsContent value="profile">
-              <div className="space-y-6">
-                <section className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:gap-5 sm:text-left">
-                  <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-xl font-semibold uppercase text-primary">
-                    {initials}
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-lg font-semibold text-gray-900">{primaryName}</p>
-                    <p className="text-sm text-muted-foreground">{renderValue(profile?.email)}</p>
-                  </div>
-                </section>
-
-                {PROFILE_SECTIONS.map((section) => (
-                  <section key={section.title} className="space-y-3">
-                    <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500">{section.title}</h2>
-                    <div className="overflow-hidden rounded-xl border border-gray-100">
-                      <dl className="divide-y divide-gray-100">
-                        {section.fields.map((field) => (
-                          <div
-                            key={field.key}
-                            className="flex flex-col gap-1 px-4 py-3 text-left sm:flex-row sm:items-start sm:justify-between"
-                          >
-                            <dt className="text-sm font-medium text-gray-500">{field.label}</dt>
-                            <dd className="text-sm font-semibold text-gray-900 sm:text-right">
-                              {renderValue(profile?.[field.key])}
-                            </dd>
-                          </div>
-                        ))}
-                      </dl>
-                    </div>
-                  </section>
-                ))}
-
-                {extraEntries.length > 0 && (
-                  <section className="space-y-3">
-                    <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500">추가 정보</h2>
-                    <div className="overflow-hidden rounded-xl border border-gray-100">
-                      <dl className="divide-y divide-gray-100">
-                        {extraEntries.map(([key, value]) => (
-                          <div
-                            key={key}
-                            className="flex flex-col gap-1 px-4 py-3 text-left sm:flex-row sm:items-start sm:justify-between"
-                          >
-                            <dt className="text-sm font-medium text-gray-500">{key}</dt>
-                            <dd className="text-sm font-semibold text-gray-900 sm:text-right">{renderValue(value)}</dd>
-                          </div>
-                        ))}
-                      </dl>
-                    </div>
-                  </section>
-                )}
-              </div>
+              <ProfileOverview
+                profile={profile}
+                primaryName={primaryName}
+                initials={initials}
+                renderValue={renderValue}
+              />
             </TabsContent>
 
             <TabsContent value="payments">
-              <div className="space-y-3">
-                <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500">결제 관리</h2>
-                <div className="space-y-2">
-                  <Button
-                    type="button"
-                    onClick={handleTossAutopay}
-                    disabled={!hasAccessToken || tossLoading}
-                    className="w-full bg-[#0064FF] text-white hover:bg-[#0050CC]"
-                  >
-                    {tossLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                    {tossLoading ? "토스로 이동 중…" : "토스 자동이체 등록"}
-                  </Button>
-                  {tossHelperText && (
-                    <p className={`text-sm ${tossHelperClass}`}>{tossHelperText}</p>
-                  )}
-                </div>
-              </div>
+              <PaymentsTab
+                hasAccessToken={hasAccessToken}
+                tossLoading={tossLoading}
+                tossHelperText={tossHelperText}
+                tossHelperClass={tossHelperClass}
+                onRequestAutopay={handleTossAutopay}
+              />
             </TabsContent>
 
             <TabsContent value="devices">
-              <div className="space-y-4">
-                {!hasAccessToken ? (
-                  <p className="text-sm text-muted-foreground text-center">
-                    디바이스 정보를 확인하려면 로그인 후 이용해주세요.
-                  </p>
-                ) : devicesLoading ? (
-                  <div className="flex flex-col items-center justify-center gap-2 py-10 text-muted-foreground">
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                    <span className="text-sm">디바이스 정보를 불러오는 중…</span>
-                  </div>
-                ) : devicesError ? (
-                  <div className="space-y-3 text-center">
-                    <p className="text-sm text-red-600">{devicesError}</p>
-                    <Button variant="outline" onClick={handleReloadDevices} disabled={devicesLoading}>
-                      다시 시도
-                    </Button>
-                  </div>
-                ) : devices.length === 0 ? (
-                  <p className="text-sm text-muted-foreground text-center">등록된 디바이스가 없습니다.</p>
-                ) : (
-                  <div className="space-y-3">
-                    {devices.map((device, index) => {
-                      const entries =
-                        device && typeof device === "object"
-                          ? Object.entries(device)
-                          : [["value", device]];
-                      const key =
-                        device?.id ??
-                        device?.deviceId ??
-                        device?.serialNumber ??
-                        device?.uuid ??
-                        index;
-                      return (
-                        <div key={key} className="overflow-hidden rounded-xl border border-gray-100 p-4">
-                          <dl className="space-y-2">
-                            {entries.map(([entryKey, entryValue]) => (
-                              <div
-                                key={entryKey}
-                                className="flex flex-col gap-1 text-left sm:flex-row sm:items-start sm:justify-between"
-                              >
-                                <dt className="text-sm font-medium text-gray-500">{entryKey}</dt>
-                                <dd className="text-sm font-semibold text-gray-900 sm:text-right">
-                                  {renderValue(entryValue)}
-                                </dd>
-                              </div>
-                            ))}
-                          </dl>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
+              <DevicesTab
+                isActive={tabValue === "devices"}
+                hasAccessToken={hasAccessToken}
+                accessToken={auth?.accessToken}
+                renderValue={renderValue}
+              />
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/src/pages/profile/components/DevicesTab.jsx
+++ b/src/pages/profile/components/DevicesTab.jsx
@@ -1,0 +1,295 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { DevicesAPI } from "@/lib/api";
+import { Loader2 } from "lucide-react";
+
+// 디바이스 목록과 등록/삭제를 모두 담당하는 탭입니다.
+const IDENTIFIER_OPTIONS = [
+  { value: "deviceId", label: "디바이스 ID" },
+  { value: "serialNumber", label: "시리얼 번호" },
+  { value: "uuid", label: "UUID" },
+];
+
+const normaliseDeviceList = (payload) => {
+  // 백엔드에서 내려오는 다양한 포맷을 통일시키기 위한 함수입니다.
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.devices)) return payload.devices;
+  if (Array.isArray(payload?.items)) return payload.items;
+  if (Array.isArray(payload?.data)) return payload.data;
+  if (Array.isArray(payload?.content)) return payload.content;
+  if (payload?.device && typeof payload.device === "object") return [payload.device];
+  if (typeof payload === "object") {
+    if ("id" in payload || "deviceId" in payload || "serialNumber" in payload) {
+      return [payload];
+    }
+  }
+  return [];
+};
+
+export default function DevicesTab({ isActive, hasAccessToken, accessToken, renderValue }) {
+  const [devices, setDevices] = useState([]);
+  const [devicesLoading, setDevicesLoading] = useState(false);
+  const [devicesError, setDevicesError] = useState("");
+  const [devicesFetched, setDevicesFetched] = useState(false);
+
+  const [identifierType, setIdentifierType] = useState(IDENTIFIER_OPTIONS[0].value);
+  const [identifierValue, setIdentifierValue] = useState("");
+  const [metadata, setMetadata] = useState("");
+  const [formError, setFormError] = useState("");
+  const [formNotice, setFormNotice] = useState("");
+  const [registering, setRegistering] = useState(false);
+  const [removingId, setRemovingId] = useState(null);
+
+  // 액세스 토큰이 바뀌면 디바이스 상태를 초기화합니다.
+  useEffect(() => {
+    setDevices([]);
+    setDevicesError("");
+    setDevicesFetched(false);
+  }, [accessToken]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    if (!hasAccessToken) return;
+    if (devicesFetched) return;
+
+    let cancelled = false;
+
+    const fetchDevices = async () => {
+      setDevicesLoading(true);
+      setDevicesError("");
+      try {
+        const response = await DevicesAPI.list(accessToken);
+        if (cancelled) return;
+        const list = normaliseDeviceList(response);
+        setDevices(Array.isArray(list) ? list : []);
+      } catch (error) {
+        if (cancelled) return;
+        setDevicesError(error?.message || "디바이스 정보를 불러오지 못했습니다.");
+        setDevices([]);
+      } finally {
+        if (!cancelled) {
+          setDevicesLoading(false);
+          setDevicesFetched(true);
+        }
+      }
+    };
+
+    fetchDevices();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken, devicesFetched, hasAccessToken, isActive]);
+
+  const refreshDevices = () => {
+    // 목록 새로고침을 단순하게 처리하기 위해 fetched 상태만 초기화합니다.
+    setDevicesFetched(false);
+  };
+
+  const handleRegister = async (event) => {
+    event.preventDefault();
+    if (!identifierValue.trim()) {
+      setFormNotice("");
+      setFormError("식별 값을 입력해주세요.");
+      return;
+    }
+
+    let extraPayload = {};
+    if (metadata.trim()) {
+      try {
+        const parsed = JSON.parse(metadata);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          throw new Error("객체 형태의 JSON 을 입력해주세요.");
+        }
+        extraPayload = parsed;
+      } catch (error) {
+        setFormNotice("");
+        setFormError(error?.message || "추가 정보는 JSON 으로 입력해주세요.");
+        return;
+      }
+    }
+
+    setRegistering(true);
+    setFormError("");
+    setFormNotice("");
+    try {
+      const payload = {
+        [identifierType]: identifierValue.trim(),
+        ...extraPayload,
+      };
+      await DevicesAPI.register(payload, accessToken);
+      setIdentifierValue("");
+      setMetadata("");
+      setFormNotice("디바이스가 성공적으로 등록되었습니다.");
+      refreshDevices();
+    } catch (error) {
+      setFormError(error?.message || "디바이스 등록에 실패했습니다.");
+    } finally {
+      setRegistering(false);
+    }
+  };
+
+  const handleRemove = async (device) => {
+    const id = device?.id ?? device?.deviceId ?? device?.serialNumber ?? device?.uuid;
+    if (!id) {
+      setDevicesError("삭제할 디바이스의 식별자를 찾지 못했습니다.");
+      return;
+    }
+
+    setRemovingId(String(id));
+    setDevicesError("");
+    try {
+      await DevicesAPI.remove(id, accessToken);
+      refreshDevices();
+    } catch (error) {
+      setDevicesError(error?.message || "디바이스 삭제에 실패했습니다.");
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  const identifierOptions = useMemo(() => IDENTIFIER_OPTIONS, []);
+
+  if (!hasAccessToken) {
+    return (
+      <p className="text-sm text-muted-foreground text-center">
+        디바이스 정보를 확인하려면 로그인 후 이용해주세요.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-4">
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">디바이스 등록</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            * 최소한 하나의 식별 값(디바이스 ID, 시리얼 번호 등)을 입력하면 됩니다. 필요하다면 JSON 으로 추가 속성을 함께 전송할 수 있습니다.
+          </p>
+        </div>
+        <form className="space-y-4" onSubmit={handleRegister}>
+          <div className="grid gap-3 sm:grid-cols-[180px_1fr]">
+            <div className="space-y-2">
+              <Label htmlFor="identifierType">식별자 종류</Label>
+              <select
+                id="identifierType"
+                value={identifierType}
+                onChange={(event) => setIdentifierType(event.target.value)}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                {identifierOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="identifierValue">식별 값</Label>
+              <Input
+                id="identifierValue"
+                value={identifierValue}
+                onChange={(event) => setIdentifierValue(event.target.value)}
+                placeholder="예: SC-000001"
+                disabled={registering}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="metadata">추가 속성 (JSON)</Label>
+            <textarea
+              id="metadata"
+              value={metadata}
+              onChange={(event) => setMetadata(event.target.value)}
+              placeholder='{"nickname": "거실용"}'
+              disabled={registering}
+              className="min-h-[96px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+            <p className="text-xs text-muted-foreground">비워두면 기본 식별 정보만 전송합니다.</p>
+          </div>
+
+          {formError && <p className="text-sm text-red-600">{formError}</p>}
+          {formNotice && <p className="text-sm text-emerald-600">{formNotice}</p>}
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={registering}>
+              {registering && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {registering ? "등록 중..." : "디바이스 등록"}
+            </Button>
+          </div>
+        </form>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">등록된 디바이스</h3>
+          <Button type="button" variant="outline" size="sm" onClick={refreshDevices} disabled={devicesLoading}>
+            새로고침
+          </Button>
+        </div>
+
+        {devicesLoading ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-10 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            <span className="text-sm">디바이스 정보를 불러오는 중…</span>
+          </div>
+        ) : devicesError ? (
+          <div className="space-y-3 text-center">
+            <p className="text-sm text-red-600">{devicesError}</p>
+            <Button variant="outline" onClick={refreshDevices} disabled={devicesLoading}>
+              다시 시도
+            </Button>
+          </div>
+        ) : devices.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center">등록된 디바이스가 없습니다.</p>
+        ) : (
+          <div className="space-y-3">
+            {devices.map((device, index) => {
+              const entries =
+                device && typeof device === "object" ? Object.entries(device) : [["value", device]];
+              const key =
+                device?.id ?? device?.deviceId ?? device?.serialNumber ?? device?.uuid ?? index;
+              const removable = Boolean(device?.id || device?.deviceId || device?.serialNumber || device?.uuid);
+
+              return (
+                <div key={key} className="overflow-hidden rounded-xl border border-gray-100 p-4">
+                  <dl className="space-y-2">
+                    {entries.map(([entryKey, entryValue]) => (
+                      <div
+                        key={entryKey}
+                        className="flex flex-col gap-1 text-left sm:flex-row sm:items-start sm:justify-between"
+                      >
+                        <dt className="text-sm font-medium text-gray-500">{entryKey}</dt>
+                        <dd className="text-sm font-semibold text-gray-900 sm:text-right">
+                          {renderValue(entryValue)}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+
+                  {removable && (
+                    <div className="mt-4 flex justify-end">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => handleRemove(device)}
+                        disabled={removingId === String(key)}
+                      >
+                        {removingId === String(key) && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        삭제
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/profile/components/PaymentsTab.jsx
+++ b/src/pages/profile/components/PaymentsTab.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+
+// 토스 자동이체 버튼만 담당하는 단순 탭입니다.
+export default function PaymentsTab({
+  hasAccessToken,
+  tossLoading,
+  tossHelperText,
+  tossHelperClass,
+  onRequestAutopay,
+}) {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500">결제 관리</h2>
+      <div className="space-y-2">
+        <Button
+          type="button"
+          onClick={onRequestAutopay}
+          disabled={!hasAccessToken || tossLoading}
+          className="w-full bg-[#0064FF] text-white hover:bg-[#0050CC]"
+        >
+          {tossLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {tossLoading ? "토스로 이동 중…" : "토스 자동이체 등록"}
+        </Button>
+        {tossHelperText && <p className={`text-sm ${tossHelperClass}`}>{tossHelperText}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/profile/components/ProfileOverview.jsx
+++ b/src/pages/profile/components/ProfileOverview.jsx
@@ -1,0 +1,89 @@
+import React, { useMemo } from "react";
+
+// 프로필 기본 정보를 정리해서 보여주는 전용 컴포넌트입니다.
+const PROFILE_SECTIONS = [
+  {
+    title: "기본 정보",
+    fields: [
+      { key: "nickname", label: "닉네임" },
+      { key: "email", label: "이메일" },
+      { key: "birthDate", label: "생년월일" },
+      { key: "phoneNumber", label: "전화번호" },
+    ],
+  },
+  {
+    title: "시스템 정보",
+    fields: [
+      { key: "id", label: "회원 ID" },
+      { key: "createdAt", label: "가입일" },
+      { key: "updatedAt", label: "정보 수정일" },
+      { key: "roles", label: "권한" },
+    ],
+  },
+];
+
+const KNOWN_PROFILE_KEYS = new Set(
+  PROFILE_SECTIONS.flatMap((section) => section.fields.map((field) => field.key))
+);
+
+export default function ProfileOverview({ profile, primaryName, initials, renderValue }) {
+  // 추가적인 프로필 키들을 자동으로 추려내기 위해 useMemo 를 활용했습니다.
+  const extraEntries = useMemo(() => {
+    if (!profile || typeof profile !== "object") return [];
+    return Object.entries(profile).filter(([key]) => !KNOWN_PROFILE_KEYS.has(key));
+  }, [profile]);
+
+  return (
+    <div className="space-y-6">
+      <section className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:gap-5 sm:text-left">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-xl font-semibold uppercase text-primary">
+          {initials}
+        </div>
+        <div className="space-y-1">
+          <p className="text-lg font-semibold text-gray-900">{primaryName}</p>
+          <p className="text-sm text-muted-foreground">{renderValue(profile?.email)}</p>
+        </div>
+      </section>
+
+      {PROFILE_SECTIONS.map((section) => (
+        <section key={section.title} className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500">{section.title}</h2>
+          <div className="overflow-hidden rounded-xl border border-gray-100">
+            <dl className="divide-y divide-gray-100">
+              {section.fields.map((field) => (
+                <div
+                  key={field.key}
+                  className="flex flex-col gap-1 px-4 py-3 text-left sm:flex-row sm:items-start sm:justify-between"
+                >
+                  <dt className="text-sm font-medium text-gray-500">{field.label}</dt>
+                  <dd className="text-sm font-semibold text-gray-900 sm:text-right">
+                    {renderValue(profile?.[field.key])}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </section>
+      ))}
+
+      {extraEntries.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500">추가 정보</h2>
+          <div className="overflow-hidden rounded-xl border border-gray-100">
+            <dl className="divide-y divide-gray-100">
+              {extraEntries.map(([key, value]) => (
+                <div
+                  key={key}
+                  className="flex flex-col gap-1 px-4 py-3 text-left sm:flex-row sm:items-start sm:justify-between"
+                >
+                  <dt className="text-sm font-medium text-gray-500">{key}</dt>
+                  <dd className="text-sm font-semibold text-gray-900 sm:text-right">{renderValue(value)}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor the profile page into smaller components for overview, payments, and devices
- add a device registration form with flexible identifiers and optional JSON metadata
- support removing devices and refreshing the list while preserving existing payment flows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d747967f2c8329b31e9375041210ab