### PR TITLE
Update devices tab to load user bindings

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -26,7 +26,11 @@ export const PaymentsAPI = {
 };
 
 export const DevicesAPI = {
-  list:    (access)         => api("/api/devices",            { access }),
+  // 사용자별 디바이스 바인딩 목록을 조회하도록 엔드포인트를 변경했습니다.
+  list:    (userId, access) => {
+    if (!userId) throw new Error("사용자 ID가 필요합니다.");
+    return api(`/api/users/${encodeURIComponent(userId)}/device-bindings`, { access });
+  },
   detail:  (deviceId, access) => api(`/api/devices/${deviceId}`, { access }),
   register: (payload, access) => api("/api/devices",          { method: "POST", body: payload, access }),
   remove:  (deviceId, access) => api(`/api/devices/${deviceId}`, { method: "DELETE", access }),

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -112,6 +112,7 @@ export default function ProfilePage() {
                 isActive={tabValue === "devices"}
                 hasAccessToken={hasAccessToken}
                 accessToken={auth?.accessToken}
+                userId={profile?.id ?? profile?.userId} // 사용자별 디바이스 바인딩 API 를 호출하기 위해 ID 를 전달합니다.
                 renderValue={renderValue}
               />
             </TabsContent>

--- a/src/pages/profile/components/DevicesTab.jsx
+++ b/src/pages/profile/components/DevicesTab.jsx
@@ -29,7 +29,7 @@ const normaliseDeviceList = (payload) => {
   return [];
 };
 
-export default function DevicesTab({ isActive, hasAccessToken, accessToken, renderValue }) {
+export default function DevicesTab({ isActive, hasAccessToken, accessToken, renderValue, userId }) {
   const [devices, setDevices] = useState([]);
   const [devicesLoading, setDevicesLoading] = useState(false);
   const [devicesError, setDevicesError] = useState("");
@@ -53,6 +53,7 @@ export default function DevicesTab({ isActive, hasAccessToken, accessToken, rend
   useEffect(() => {
     if (!isActive) return;
     if (!hasAccessToken) return;
+    if (!userId) return; // 사용자 ID 를 확보한 뒤에만 조회하도록 가드합니다.
     if (devicesFetched) return;
 
     let cancelled = false;
@@ -61,7 +62,7 @@ export default function DevicesTab({ isActive, hasAccessToken, accessToken, rend
       setDevicesLoading(true);
       setDevicesError("");
       try {
-        const response = await DevicesAPI.list(accessToken);
+        const response = await DevicesAPI.list(userId, accessToken);
         if (cancelled) return;
         const list = normaliseDeviceList(response);
         setDevices(Array.isArray(list) ? list : []);
@@ -82,7 +83,7 @@ export default function DevicesTab({ isActive, hasAccessToken, accessToken, rend
     return () => {
       cancelled = true;
     };
-  }, [accessToken, devicesFetched, hasAccessToken, isActive]);
+  }, [accessToken, devicesFetched, hasAccessToken, isActive, userId]);
 
   const refreshDevices = () => {
     // 목록 새로고침을 단순하게 처리하기 위해 fetched 상태만 초기화합니다.


### PR DESCRIPTION
## Summary
- update the devices API helper to query the user-specific device binding endpoint
- pass the authenticated user id into the devices tab and guard the fetch until the id is available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d751b568408329b4e02839a24f6536