### PR TITLE
Add additional payment buttons and fix bearer token duplication

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -2,7 +2,11 @@ const API_BASE = import.meta.env.VITE_API_BASE_URL || "http://localhost:8081";
 
 export async function api(path, { method = "GET", body, access } = {}) {
   const headers = { "Content-Type": "application/json" };
-  if (access) headers["Authorization"] = `Bearer ${access}`;
+  if (access) {
+    // 백엔드가 이미 "Bearer " 접두사가 붙은 토큰을 내려주는 경우가 있어 중복을 방지합니다.
+    const normalized = access.startsWith("Bearer ") ? access : `Bearer ${access}`;
+    headers["Authorization"] = normalized;
+  }
   const res = await fetch(`${API_BASE}${path}`, {
     method,
     headers,

--- a/src/pages/profile/components/PaymentsTab.jsx
+++ b/src/pages/profile/components/PaymentsTab.jsx
@@ -2,13 +2,17 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 
-// 토스 자동이체 버튼만 담당하는 단순 탭입니다.
+// 토스/네이버/카카오 간편결제 버튼 묶음을 담당하는 탭입니다.
 export default function PaymentsTab({
   hasAccessToken,
   tossLoading,
   tossHelperText,
   tossHelperClass,
   onRequestAutopay,
+  onRequestNaverPay,
+  onRequestKakaoPay,
+  naverPayHelperText,
+  kakaoPayHelperText,
 }) {
   return (
     <div className="space-y-3">
@@ -24,6 +28,30 @@ export default function PaymentsTab({
           {tossLoading ? "토스로 이동 중…" : "토스 자동이체 등록"}
         </Button>
         {tossHelperText && <p className={`text-sm ${tossHelperClass}`}>{tossHelperText}</p>}
+      </div>
+      <div className="space-y-2">
+        <Button
+          type="button"
+          onClick={onRequestNaverPay}
+          disabled={!hasAccessToken}
+          className="w-full bg-[#03C75A] text-white hover:bg-[#02b152]"
+        >
+          {/* 네이버페이는 아직 외부 연동 전용 API 가 없어 별도 로딩 스피너는 표시하지 않습니다. */}
+          네이버페이 결제 이동
+        </Button>
+        {naverPayHelperText && <p className="text-sm text-muted-foreground">{naverPayHelperText}</p>}
+      </div>
+      <div className="space-y-2">
+        <Button
+          type="button"
+          onClick={onRequestKakaoPay}
+          disabled={!hasAccessToken}
+          className="w-full bg-[#FEE500] text-[#181600] hover:bg-[#F7D102]"
+        >
+          {/* 카카오페이 역시 현재는 안내 메시지만 제공하여 사용자 기대를 관리합니다. */}
+          카카오페이 결제 이동
+        </Button>
+        {kakaoPayHelperText && <p className="text-sm text-muted-foreground">{kakaoPayHelperText}</p>}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add KakaoPay and NaverPay buttons with helper messaging to the profile payment tab
- reuse a shared handler in the profile page so external payment URLs can be customized by environment
- normalise the Authorization header builder to avoid duplicating the Bearer prefix when the backend already sends it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fa0b0f481c83299686f9ce97ebca57